### PR TITLE
Add the ability to read input line by line

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ LEFT
 REPORT
 ```
 
+The simulator can also read input typed in the console by reading from Standard Input.  See the section on [Running the Simulator](#running-the-simulator) below.
+
 ### Command Reference
 
 Commands and arguments are not case sensitive - any combination of upper and lower case characters will work. For example, the following are equivalent:
@@ -109,6 +111,37 @@ PLACE 0,0,NORTH
 MOVE
 REPORT
 Output: 0,1,NORTH
+
+Simulation ended.
+```
+
+You can also run the simulator and type in your commands one line at a time. Invoke the `stdin` rake task:
+
+```
+$ cd ~/toyrobot
+$ bundle exec rake stdin
+```
+
+Then type some commands. For example:
+
+```
+Robot Simulator
+---------------
+Type one command at a time then press ENTER
+Valid commands are:
+        PLACE X,Y,DIRECTION
+        MOVE
+        LEFT
+        RIGHT
+        REPORT
+Press ENTER without any commands to exit
+
+PLACE 2,2,EAST
+MOVE
+RIGHT
+MOVE
+REPORT
+Output: 3,1,SOUTH
 
 Simulation ended.
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,29 @@ task :run do
   file_processor.process_on(simulator)
   puts "\nSimulation ended."
 end
+
+desc 'Run the Robot Simulator reading commands from standard input'
+task :stdin do
+  $LOAD_PATH.unshift(File.dirname(__FILE__), 'lib')
+  require 'simulator'
+  require 'file_processor'
+
+  puts 'Robot Simulator'
+  puts '---------------'
+  puts 'Type one command at a time then press ENTER'
+  puts 'Valid commands are:'
+  puts "\tPLACE X,Y,DIRECTION"
+  puts "\tMOVE"
+  puts "\tLEFT"
+  puts "\tRIGHT"
+  puts "\tREPORT"
+  puts "Press ENTER without any commands to exit\n\n"
+
+  simulator = Simulator.new
+  while input_line = $stdin.gets
+    input_line.strip!
+    break if input_line == ''
+    simulator.process(input_line)
+  end
+  puts 'Simulation ended.'
+end


### PR DESCRIPTION
In response to Issue https://github.com/lessan/toyrobot/issues/1

I decided not to have an EXIT command, but rather, to quit when receiving an empty command string (i.e. ENTER is pressed on its own).
